### PR TITLE
feat: add 'data' key to full datasets

### DIFF
--- a/services/analytics.js
+++ b/services/analytics.js
@@ -10,10 +10,10 @@ const fetchActions = (collection, spaceIds, { sampleSize } = {}) => {
         },
       },
     },
-    { $project: { data: 0 } },
   ];
 
   if (sampleSize) {
+    aggregateQuery.push({ $project: { data: 0 } });
     aggregateQuery.push({ $sample: { size: sampleSize } });
   }
 


### PR DESCRIPTION
for full dataset requests, include 'data' key of retrieved action objects

closes #24